### PR TITLE
Feature/wifi latency optimizations + Power Save mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ hifi-wifi runs automatically in the background. You don't need to do anything.
 
 | Command | Description |
 |---------|-------------|
-| `hifi-wifi status` | Check if it's working ||
+| `hifi-wifi status` | Check if it's working |
+| `sudo hifi-wifi power-save off` | Maximum WiFi performance (persists across sleep/reboot) |
+| `sudo hifi-wifi power-save adaptive` | Automatic power save based on AC/battery (default) |
+| `hifi-wifi power-save status` | Show current power save mode and actual state |
 | `sudo hifi-wifi on/off` | Start/stop the service |
 | `sudo hifi-wifi uninstall` | Remove completely |
 
@@ -74,6 +77,20 @@ Works on any Linux system with NetworkManager and systemd.
 ## Configuration (Optional)
 
 hifi-wifi works great with default settings. Advanced users can customize:
+
+### WiFi Power Save
+
+By default, hifi-wifi uses **adaptive** power save (off on AC, on when on battery). If you experience WiFi issues on Steam Deck (stuttering, disconnects, slow speeds), force it off:
+
+```bash
+sudo hifi-wifi power-save off
+```
+
+This persists across sleep, reboot, and SteamOS updates. To revert to automatic mode:
+
+```bash
+sudo hifi-wifi power-save adaptive
+```
 
 **Config File:** `/etc/hifi-wifi/config.toml` (created on first run)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ hifi-wifi automatically optimizes your network for gaming - no configuration nee
 ## What It Does
 
 - **Eliminates stuttering** during online gaming and game streaming
+- **Suppresses latency spikes** caused by background WiFi scanning (170ms → 4ms)
 - **Picks the fastest WiFi** automatically (prefers 5GHz/6GHz over 2.4GHz)
 - **Reduces lag** with intelligent traffic shaping (CAKE qdisc)
 - **Saves battery** on Steam Deck while maintaining performance
@@ -52,6 +53,9 @@ hifi-wifi runs automatically in the background. You don't need to do anything.
 | `sudo hifi-wifi power-save off` | Maximum WiFi performance (persists across sleep/reboot) |
 | `sudo hifi-wifi power-save adaptive` | Automatic power save based on AC/battery (default) |
 | `hifi-wifi power-save status` | Show current power save mode and actual state |
+| `sudo hifi-wifi scan-suppress on` | Suppress background scans for lowest latency (default) |
+| `sudo hifi-wifi scan-suppress off` | Allow background scans (enables roaming) |
+| `hifi-wifi scan-suppress status` | Show current scan suppression state |
 | `sudo hifi-wifi on/off` | Start/stop the service |
 | `sudo hifi-wifi uninstall` | Remove completely |
 
@@ -92,6 +96,22 @@ This persists across sleep, reboot, and SteamOS updates. To revert to automatic 
 sudo hifi-wifi power-save adaptive
 ```
 
+### Scan Suppression
+
+WiFi drivers perform background channel scans every ~15 seconds, causing **170ms latency spikes** that affect gaming and streaming. hifi-wifi suppresses these scans by default, reducing latency to **~3.5ms average / 4ms max**.
+
+The tradeoff: with scan suppression on, WiFi roaming between access points is disabled. For most users (single AP, fixed location), this is the right default. If you have multiple access points and need roaming:
+
+```bash
+sudo hifi-wifi scan-suppress off
+```
+
+To re-enable (recommended for gaming):
+
+```bash
+sudo hifi-wifi scan-suppress on
+```
+
 **Config File:** `/etc/hifi-wifi/config.toml` (created on first run)
 
 ---
@@ -120,7 +140,7 @@ Then install normally.
 
 ## How It Works
 
-hifi-wifi uses the CAKE traffic shaper to manage network congestion, monitors your connection quality, and adjusts settings in real-time. It detects WiFi reconnections, roaming events, and power state changes to keep optimizations current.
+hifi-wifi uses the CAKE traffic shaper to manage network congestion, suppresses latency-causing background WiFi scans, monitors your connection quality, and adjusts settings in real-time. It detects WiFi reconnections, roaming events, and power state changes to keep optimizations current.
 
 **[Read the full architecture documentation →](ARCHITECTURE.md)**
 

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -126,6 +126,7 @@ impl Default for BackendConfig {
 
 /// Governor-specific settings (the "brain" of hifi-wifi)
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct GovernorConfig {
     /// Enable dynamic CAKE bandwidth adjustment
     pub breathing_cake_enabled: bool,

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -73,12 +73,17 @@ impl Default for WifiConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct PowerConfig {
     #[allow(dead_code)]
+    #[serde(default = "default_true")]
     pub enabled: bool,
+    #[serde(default = "default_adaptive")]
     pub wlan_power_save: String, // "on", "off", "adaptive"
 }
+
+fn default_true() -> bool { true }
+fn default_adaptive() -> String { "adaptive".to_string() }
 
 impl Default for PowerConfig {
     fn default() -> Self {

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -163,6 +163,13 @@ pub struct GovernorConfig {
     
     /// Rolling average window size for CPU monitoring
     pub cpu_avg_window_size: usize,
+
+    /// Suppress iwd background scans to eliminate latency spikes
+    /// When true (default), the Governor aborts background scans every 500ms
+    /// while connected, reducing latency from ~20ms avg/170ms max to ~3.5ms avg/4ms max.
+    /// Disables roaming and band steering while active (scans resume if disconnected).
+    #[serde(default = "default_true")]
+    pub scan_suppress: bool,
 }
 
 impl Default for GovernorConfig {
@@ -188,6 +195,8 @@ impl Default for GovernorConfig {
             cpu_coalescing_threshold: 0.90,
             
             cpu_avg_window_size: 3,
+
+            scan_suppress: true,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -457,11 +457,14 @@ async fn run_status_async() -> Result<()> {
             .unwrap_or_default();
         
         if qdisc_out.contains("cake") {
-             // Extract bandwidth if possible
+             // Extract bandwidth and RTT if possible
              let bw = qdisc_out.split("bandwidth ").nth(1)
                 .and_then(|s| s.split_whitespace().next())
                 .unwrap_or("unknown");
-             println!("{}│{}    ├─ CAKE:       {}[ACTIVE]{} Bandwidth: {}", BLUE, NC, GREEN, NC, bw);
+             let rtt = qdisc_out.split("rtt ").nth(1)
+                .and_then(|s| s.split_whitespace().next())
+                .unwrap_or("default");
+             println!("{}│{}    ├─ CAKE:       {}[ACTIVE]{} Bandwidth: {} RTT: {}", BLUE, NC, GREEN, NC, bw, rtt);
         } else {
              println!("{}│{}    ├─ CAKE:       {}[INACTIVE]{}", BLUE, NC, RED, NC);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,12 @@ enum Commands {
     On,
     /// Bootstrap: Check and repair system service (runs on boot via user timer)
     Bootstrap,
+    /// Control WiFi power save mode (off/on/adaptive/status)
+    #[command(name = "power-save")]
+    PowerSave {
+        /// Mode: off (best performance), on (battery saving), adaptive (automatic), status (show current)
+        mode: String,
+    },
 }
 
 #[tokio::main]
@@ -55,13 +61,15 @@ async fn main() -> Result<()> {
     
     let cli = Cli::parse();
 
-    // Suppress INFO logs for status command (clean output)
-    if matches!(cli.command, Some(Commands::Status)) {
+    // Suppress INFO logs for status-like commands (clean output)
+    let is_status_cmd = matches!(cli.command, Some(Commands::Status))
+        || matches!(cli.command, Some(Commands::PowerSave { ref mode }) if mode == "status");
+    if is_status_cmd {
         log::set_max_level(log::LevelFilter::Warn);
     }
 
-    // Root check (except for status command)
-    if !matches!(cli.command, Some(Commands::Status)) && !utils::privilege::is_root() {
+    // Root check (except for status commands)
+    if !is_status_cmd && !utils::privilege::is_root() {
         error!("This application must be run as root.");
         error!("Try: sudo hifi-wifi");
         std::process::exit(1);
@@ -101,6 +109,9 @@ async fn main() -> Result<()> {
         }
         Commands::Bootstrap => {
             run_bootstrap()?;
+        }
+        Commands::PowerSave { mode } => {
+            run_power_save(&mode, &config)?;
         }
     }
 
@@ -151,6 +162,11 @@ fn run_apply(config: &config::structs::Config) -> Result<()> {
             info!("Optimizing {} active interface(s)", active_interfaces.len());
             sys_opt.apply(&active_interfaces)?;
         }
+    }
+
+    // 3b. Write persistent NetworkManager power save config (survives sleep/wake)
+    if let Err(e) = write_nm_powersave_config(&config.power.wlan_power_save) {
+        warn!("Failed to write NM powersave config: {}", e);
     }
 
     // 4. Apply power-aware settings
@@ -277,6 +293,9 @@ fn run_revert() -> Result<()> {
         }
     }
 
+    // Remove NM power save config
+    remove_nm_powersave_config();
+
     // Revert system optimizations
     let sys_opt = SystemOptimizer::default();
     sys_opt.revert()?;
@@ -308,7 +327,7 @@ async fn run_monitor(config: &config::structs::Config) -> Result<()> {
     run_apply(config)?;
 
     // Start the Governor
-    let mut governor = Governor::new(config.governor.clone(), config.wifi.clone()).await?;
+    let mut governor = Governor::new(config.governor.clone(), config.wifi.clone(), config.power.clone()).await?;
     
     info!("Governor initialized, entering main loop (tick: {}s)", 
           config.global.tick_rate_secs);
@@ -787,7 +806,7 @@ fn install_nm_dispatcher() -> Result<()> {
     let dispatcher_content = r#"#!/bin/bash
 # hifi-wifi NetworkManager dispatcher
 # Signals the daemon when WiFi connects so it can apply fresh optimizations
-# Per roadmap-beta2.md: This fixes the "reconnection problem" (Issue #10)
+# Also enforces power save settings immediately on connection (belt-and-suspenders)
 
 INTERFACE="$1"
 ACTION="$2"
@@ -802,6 +821,16 @@ fi
 
 # Ensure run directory exists
 mkdir -p /run/hifi-wifi
+
+# Enforce power save setting from NM config (immediate, before daemon picks it up)
+NM_PS_CONF="/etc/NetworkManager/conf.d/99-hifi-wifi-powersave.conf"
+if [[ -f "$NM_PS_CONF" ]]; then
+    PS_VALUE=$(awk -F= '/wifi\.powersave/{gsub(/[^0-9]/,"",$2); print $2}' "$NM_PS_CONF" 2>/dev/null)
+    case "$PS_VALUE" in
+        2) iw dev "$INTERFACE" set power_save off 2>/dev/null ;;
+        3) iw dev "$INTERFACE" set power_save on 2>/dev/null ;;
+    esac
+fi
 
 # Signal the daemon by touching the event file
 # The daemon watches this with inotify and triggers re-optimization
@@ -1051,6 +1080,7 @@ fn run_uninstall() -> Result<()> {
         "/var/lib/hifi-wifi/hifi-wifi-bootstrap.service",
         "/var/lib/hifi-wifi/hifi-wifi-bootstrap.timer",
         "/etc/NetworkManager/dispatcher.d/99-hifi-wifi-connect",
+        "/etc/NetworkManager/conf.d/99-hifi-wifi-powersave.conf",
     ];
     
     for path in &files_to_remove {
@@ -1316,6 +1346,270 @@ WantedBy=multi-user.target
     } else {
         info!("Bootstrap: Optimizations applied successfully");
     }
-    
+
+    Ok(())
+}
+
+// ============================================================================
+// Power Save Control
+// ============================================================================
+
+/// Path for the persistent NetworkManager power save config
+const NM_POWERSAVE_CONF: &str = "/etc/NetworkManager/conf.d/99-hifi-wifi-powersave.conf";
+/// Path for the hifi-wifi config file
+const HIFI_CONFIG_PATH: &str = "/etc/hifi-wifi/config.toml";
+
+/// Write a NetworkManager config file that persistently controls WiFi power save.
+/// NM reads conf.d on every connection activation, so this survives sleep/wake.
+///
+/// wifi.powersave values:
+///   1 = ignore (use default / let hifi-wifi adaptive logic control it)
+///   2 = disable
+///   3 = enable
+fn write_nm_powersave_config(mode: &str) -> Result<()> {
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    let nm_value = match mode {
+        "off" => 2,
+        "on" => 3,
+        _ => 1, // adaptive — NM ignores, hifi-wifi controls
+    };
+
+    let content = format!(
+        "# hifi-wifi WiFi power save configuration\n\
+         # Auto-generated by hifi-wifi — do not edit manually\n\
+         # Mode: {}\n\
+         [connection]\n\
+         wifi.powersave = {}\n",
+        mode, nm_value
+    );
+
+    let conf_dir = std::path::Path::new("/etc/NetworkManager/conf.d");
+    if !conf_dir.exists() {
+        fs::create_dir_all(conf_dir)?;
+    }
+
+    match File::create(NM_POWERSAVE_CONF) {
+        Ok(mut file) => {
+            file.write_all(content.as_bytes())?;
+            info!("Created NM power save config: {} (wifi.powersave={})", NM_POWERSAVE_CONF, nm_value);
+
+            // Reload NM to pick up the new config immediately
+            let _ = std::process::Command::new("nmcli")
+                .args(["general", "reload"])
+                .output();
+        }
+        Err(e) => {
+            warn!("Could not create NM powersave config (Read-only filesystem?): {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Remove the persistent NetworkManager power save config
+fn remove_nm_powersave_config() {
+    if std::path::Path::new(NM_POWERSAVE_CONF).exists() {
+        let _ = std::fs::remove_file(NM_POWERSAVE_CONF);
+        info!("Removed NM power save config: {}", NM_POWERSAVE_CONF);
+
+        // Reload NM so it stops enforcing the old setting
+        let _ = std::process::Command::new("nmcli")
+            .args(["general", "reload"])
+            .output();
+    }
+}
+
+/// Write the hifi-wifi config file with the specified power save mode
+fn write_hifi_config(mode: &str) -> Result<()> {
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    let config_dir = std::path::Path::new("/etc/hifi-wifi");
+    fs::create_dir_all(config_dir)?;
+
+    // Read existing config or start fresh
+    let existing = fs::read_to_string(HIFI_CONFIG_PATH).unwrap_or_default();
+
+    // Update or insert the power save setting
+    let new_content = if existing.contains("[power]") {
+        // Replace existing wlan_power_save line
+        let mut result = String::new();
+        let mut in_power_section = false;
+        let mut replaced = false;
+        for line in existing.lines() {
+            if line.trim() == "[power]" {
+                in_power_section = true;
+                result.push_str(line);
+                result.push('\n');
+            } else if line.trim().starts_with('[') {
+                if in_power_section && !replaced {
+                    // [power] section existed but had no wlan_power_save — insert before next section
+                    result.push_str(&format!("wlan_power_save = \"{}\"\n", mode));
+                    replaced = true;
+                }
+                in_power_section = false;
+                result.push_str(line);
+                result.push('\n');
+            } else if in_power_section && line.trim().starts_with("wlan_power_save") {
+                result.push_str(&format!("wlan_power_save = \"{}\"", mode));
+                result.push('\n');
+                replaced = true;
+            } else {
+                result.push_str(line);
+                result.push('\n');
+            }
+        }
+        if in_power_section && !replaced {
+            result.push_str(&format!("wlan_power_save = \"{}\"", mode));
+            result.push('\n');
+        }
+        result
+    } else {
+        // No [power] section exists — append it
+        let mut result = existing;
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&format!("\n[power]\nenabled = true\nwlan_power_save = \"{}\"\n", mode));
+        result
+    };
+
+    let mut file = File::create(HIFI_CONFIG_PATH)?;
+    file.write_all(new_content.as_bytes())?;
+    info!("Updated config: {} (wlan_power_save = \"{}\")", HIFI_CONFIG_PATH, mode);
+
+    Ok(())
+}
+
+/// Control WiFi power save mode
+fn run_power_save(mode: &str, config: &config::structs::Config) -> Result<()> {
+    use std::process::Command;
+
+    // ANSI Colors
+    const GREEN: &str = "\x1b[0;32m";
+    const YELLOW: &str = "\x1b[0;33m";
+    const BLUE: &str = "\x1b[0;34m";
+    const BOLD: &str = "\x1b[1m";
+    const NC: &str = "\x1b[0m";
+
+    match mode {
+        "status" => {
+            println!();
+            println!("{}{}Power Save Status{}", BOLD, BLUE, NC);
+            println!("{}─────────────────────{}", BLUE, NC);
+
+            // Show configured mode
+            let configured = &config.power.wlan_power_save;
+            let mode_display = match configured.as_str() {
+                "off" => format!("{}OFF{} (Maximum Performance)", GREEN, NC),
+                "on" => format!("{}ON{} (Battery Saving)", YELLOW, NC),
+                _ => format!("{}ADAPTIVE{} (Automatic)", BLUE, NC),
+            };
+            println!("  Config mode: {}", mode_display);
+
+            // Show NM persistent config
+            if std::path::Path::new(NM_POWERSAVE_CONF).exists() {
+                let nm_content = std::fs::read_to_string(NM_POWERSAVE_CONF).unwrap_or_default();
+                let nm_val = nm_content.lines()
+                    .find(|l| l.contains("wifi.powersave"))
+                    .and_then(|l| l.split('=').nth(1))
+                    .map(|v| v.trim())
+                    .unwrap_or("?");
+                let nm_desc = match nm_val {
+                    "2" => "disable (persistent)",
+                    "3" => "enable (persistent)",
+                    "1" => "ignore (adaptive)",
+                    _ => "unknown",
+                };
+                println!("  NM config:   wifi.powersave = {} ({})", nm_val, nm_desc);
+            } else {
+                println!("  NM config:   not set");
+            }
+
+            // Show actual iw state per interface
+            let wifi_mgr = WifiManager::new_quiet()?;
+            for ifc in wifi_mgr.interfaces() {
+                if ifc.interface_type != crate::network::wifi::InterfaceType::Wifi {
+                    continue;
+                }
+                let ps_out = Command::new("iw")
+                    .args(["dev", &ifc.name, "get", "power_save"])
+                    .output()
+                    .ok()
+                    .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
+                    .unwrap_or_default();
+
+                let actual = if ps_out.contains("off") {
+                    format!("{}OFF{}", GREEN, NC)
+                } else if ps_out.contains("on") {
+                    format!("{}ON{}", YELLOW, NC)
+                } else {
+                    "unknown".to_string()
+                };
+                println!("  {}: power_save = {}", ifc.name, actual);
+            }
+            println!();
+        }
+        "off" | "on" | "adaptive" => {
+            let mode_desc = match mode {
+                "off" => "OFF (Maximum Performance — persists across sleep/reboot)",
+                "on" => "ON (Battery Saving — persists across sleep/reboot)",
+                _ => "ADAPTIVE (Automatic based on AC/battery)",
+            };
+            info!("Setting WiFi power save to: {}", mode_desc);
+
+            // 1. Write hifi-wifi config file
+            write_hifi_config(mode)?;
+
+            // 2. Write persistent NM config
+            write_nm_powersave_config(mode)?;
+
+            // 3. Apply immediately via iw on all connected WiFi interfaces
+            let wifi_mgr = WifiManager::new()?;
+            for ifc in wifi_mgr.interfaces() {
+                if ifc.interface_type != crate::network::wifi::InterfaceType::Wifi {
+                    continue;
+                }
+                if !wifi_mgr.is_interface_connected(ifc) {
+                    continue;
+                }
+                match mode {
+                    "off" => {
+                        wifi_mgr.disable_power_save(ifc)?;
+                        info!("Power save disabled on {}", ifc.name);
+                    }
+                    "on" => {
+                        wifi_mgr.enable_power_save(ifc)?;
+                        info!("Power save enabled on {}", ifc.name);
+                    }
+                    _ => {
+                        // Adaptive: let the governor handle it
+                        info!("Power save set to adaptive on {} (governor will manage)", ifc.name);
+                    }
+                }
+            }
+
+            // 4. Restart service if running so Governor picks up the new config
+            let service_running = Command::new("systemctl")
+                .args(["is-active", "--quiet", "hifi-wifi.service"])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+
+            if service_running {
+                info!("Restarting hifi-wifi service to apply new config...");
+                let _ = Command::new("systemctl").args(["restart", "hifi-wifi.service"]).output();
+            }
+
+            info!("Power save mode set to '{}' successfully", mode);
+        }
+        _ => {
+            error!("Invalid mode: '{}'. Use: off, on, adaptive, or status", mode);
+            std::process::exit(1);
+        }
+    }
+
     Ok(())
 }

--- a/src/network/wifi.rs
+++ b/src/network/wifi.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+use crate::network::tc::detect_gateway_rtt;
+
 /// Interface type (WiFi or Ethernet)
 #[derive(Debug, Clone, PartialEq)]
 pub enum InterfaceType {
@@ -293,6 +295,7 @@ impl WifiManager {
             .args([
                 "qdisc", "replace", "dev", &ifc.name, "root", "cake",
                 "bandwidth", &bandwidth,
+                "rtt", detect_gateway_rtt(),
                 "diffserv4", "dual-dsthost", "nat", "wash", "ack-filter"
             ])
             .output()

--- a/src/system/optimizer.rs
+++ b/src/system/optimizer.rs
@@ -45,11 +45,6 @@ impl SystemOptimizer {
             }
         }
 
-        // Apply NAPI busy polling per interface
-        for ifc in interfaces {
-            self.apply_napi_tuning(&ifc.name);
-        }
-
         // Apply ethtool optimizations
         for ifc in interfaces {
             self.apply_ethtool_settings(ifc)?;
@@ -77,10 +72,6 @@ impl SystemOptimizer {
             ("net.ipv4.tcp_keepalive_intvl", "10"),
             ("net.ipv4.tcp_keepalive_probes", "6"),
             ("net.ipv4.tcp_tw_reuse", "1"),
-            // NAPI busy polling: kernel polls NIC for packets in tight loop
-            // instead of waiting for interrupts, reducing per-packet latency by ~50-100us
-            ("net.core.busy_poll", "50"),
-            ("net.core.busy_read", "50"),
         ];
 
         let sysctl_path = Path::new("/etc/sysctl.d/99-hifi-wifi.conf");
@@ -135,28 +126,6 @@ impl SystemOptimizer {
         }
 
         Ok(())
-    }
-
-    /// Apply per-interface NAPI busy polling parameters
-    ///
-    /// Configures the kernel to defer hard IRQs and use GRO flush timeout,
-    /// allowing busy polling to batch packet processing and reduce latency.
-    fn apply_napi_tuning(&self, interface: &str) {
-        let napi_defer_path = format!("/sys/class/net/{}/napi_defer_hard_irqs", interface);
-        let gro_flush_path = format!("/sys/class/net/{}/gro_flush_timeout", interface);
-
-        match fs::write(&napi_defer_path, "2") {
-            Ok(_) => debug!("Set napi_defer_hard_irqs=2 for {}", interface),
-            Err(e) => debug!("Could not set napi_defer_hard_irqs for {}: {}", interface, e),
-        }
-
-        // 20000ns = 20us flush timeout
-        match fs::write(&gro_flush_path, "20000") {
-            Ok(_) => debug!("Set gro_flush_timeout=20000 for {}", interface),
-            Err(e) => debug!("Could not set gro_flush_timeout for {}: {}", interface, e),
-        }
-
-        info!("NAPI busy polling configured for {}", interface);
     }
 
     /// Apply driver-specific module parameters

--- a/src/system/optimizer.rs
+++ b/src/system/optimizer.rs
@@ -244,14 +244,15 @@ options mwifiex disable_auto_ds=1
         let search_terms: Vec<&str> = match ifc.driver.as_str() {
             "rtl8192ee" => vec!["rtl_pci"],
             "rtw88_8822ce" | "rtw88_pci" | "rtw_pci" => vec!["rtw88", "rtw_pci", &ifc.name],
-            "ath11k_pci" | "ath11k" => vec!["ath11k", "wcn", "MHI", &ifc.name],  // WCN6855 variants
+            "ath11k_pci" | "ath11k" => vec!["ath11k", "wcn", "mhi", "bhi", &ifc.name],  // WCN6855 variants
             _ => vec![ifc.driver.as_str(), &ifc.name],
         };
 
         // Find ALL matching IRQs (important for MSI-X drivers like ath11k)
         let irqs: Vec<String> = interrupts.lines()
             .filter(|line| {
-                search_terms.iter().any(|term| line.contains(term)) || line.contains(&ifc.name)
+                let lower = line.to_lowercase();
+                search_terms.iter().any(|term| lower.contains(&term.to_lowercase())) || lower.contains(&ifc.name.to_lowercase())
             })
             .filter_map(|line| line.trim().split(':').next())
             .map(|s| s.trim().to_string())

--- a/src/system/optimizer.rs
+++ b/src/system/optimizer.rs
@@ -45,6 +45,11 @@ impl SystemOptimizer {
             }
         }
 
+        // Apply NAPI busy polling per interface
+        for ifc in interfaces {
+            self.apply_napi_tuning(&ifc.name);
+        }
+
         // Apply ethtool optimizations
         for ifc in interfaces {
             self.apply_ethtool_settings(ifc)?;
@@ -72,6 +77,10 @@ impl SystemOptimizer {
             ("net.ipv4.tcp_keepalive_intvl", "10"),
             ("net.ipv4.tcp_keepalive_probes", "6"),
             ("net.ipv4.tcp_tw_reuse", "1"),
+            // NAPI busy polling: kernel polls NIC for packets in tight loop
+            // instead of waiting for interrupts, reducing per-packet latency by ~50-100us
+            ("net.core.busy_poll", "50"),
+            ("net.core.busy_read", "50"),
         ];
 
         let sysctl_path = Path::new("/etc/sysctl.d/99-hifi-wifi.conf");
@@ -126,6 +135,28 @@ impl SystemOptimizer {
         }
 
         Ok(())
+    }
+
+    /// Apply per-interface NAPI busy polling parameters
+    ///
+    /// Configures the kernel to defer hard IRQs and use GRO flush timeout,
+    /// allowing busy polling to batch packet processing and reduce latency.
+    fn apply_napi_tuning(&self, interface: &str) {
+        let napi_defer_path = format!("/sys/class/net/{}/napi_defer_hard_irqs", interface);
+        let gro_flush_path = format!("/sys/class/net/{}/gro_flush_timeout", interface);
+
+        match fs::write(&napi_defer_path, "2") {
+            Ok(_) => debug!("Set napi_defer_hard_irqs=2 for {}", interface),
+            Err(e) => debug!("Could not set napi_defer_hard_irqs for {}: {}", interface, e),
+        }
+
+        // 20000ns = 20us flush timeout
+        match fs::write(&gro_flush_path, "20000") {
+            Ok(_) => debug!("Set gro_flush_timeout=20000 for {}", interface),
+            Err(e) => debug!("Could not set gro_flush_timeout for {}: {}", interface, e),
+        }
+
+        info!("NAPI busy polling configured for {}", interface);
     }
 
     /// Apply driver-specific module parameters


### PR DESCRIPTION
Hello!

This PR introduces a bunch of improvements and fixes some WiFi latency issues I had while testing with my Steam Deck.                                                                                                                                             
                                                                                                                                                                                                                                    
Implemented **Scan suppression** feature - turns out the WiFi driver scans channels every 15 seconds even when connected, causing ~150ms latency spikes. Added a background task that suppresses these scans, bringing spikes down to ~3-5ms. Should improve experience during moonlight streaming (my case).                                                                                                                                                         
                                                                                                                                                                                                                                    
Also added a `power-save` CLI command since the adaptive logic kept re-enabling power save on battery even when I wanted it off. Now you can just `hifi-wifi power-save off` and it should stick through sleep/reboot.  The issue with Power Save mode was described here -> #16          
                                                                                                                                                                                                                                    
Other improvements:                                                                                                                                                                                                                      
  - CAKE RTT now auto-detects from gateway ping instead of assuming 100ms                                                                                                                                                           
  - Fixed IRQ affinity on Steam Deck OLED (kernel uses lowercase `mhi`, we were looking for `MHI`)                                                                                                                                  
  - NAPI busy polling for a bit less packet latency                                                                                                                                                                                 
  - Minor config parsing fix                                             

Tested these things on my Steam Deck OLED in 5Ghz and 6Ghz environment, everything works fine and stays through reboots/reconnections/etc
                                                                                                                                                                                                        
I've seen you already had some work on Power Save CLI, was not sure how to proceed with it, since I already developed mine as a feature in fork and tested it quite a bit. Happy to adjust anything if needed. 