### PR TITLE
Wifi module firmware update / new experimental feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ toml = "0.9.10"
 zbus = "5.12.0"
 
 # Firmware update feature dependencies
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
-zstd = "0.13"
+# Uses system curl and zstd commands (pre-installed on SteamOS) to avoid C compilation issues
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,10 @@ serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "0.9.10"
 zbus = "5.12.0"
+
+# Firmware update feature dependencies
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
+zstd = "0.13"
+sha2 = "0.10"
+chrono = { version = "0.4", features = ["serde"] }
+tempfile = "3.15"

--- a/src/firmware/deploy.rs
+++ b/src/firmware/deploy.rs
@@ -1,0 +1,399 @@
+//! Firmware deployment and backup management
+//!
+//! Handles:
+//! - Creating backups before first update
+//! - Compressing and deploying new firmware
+//! - Reverting to backup
+//! - SteamOS readonly filesystem handling
+
+use anyhow::{Result, Context, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Sha256, Digest};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::firmware::version::FirmwareVersion;
+
+/// Files we manage (NOT Data.msc - that's Valve-specific)
+const MANAGED_FILES: &[&str] = &["amss.bin.zst", "m3.bin.zst", "board-2.bin.zst"];
+
+/// Backup file suffix
+const BACKUP_SUFFIX: &str = ".hifi-backup";
+
+/// Backup metadata filename
+const BACKUP_METADATA_FILE: &str = ".hifi-backup.json";
+
+/// Zstd compression level (match SteamOS default)
+const ZSTD_COMPRESSION_LEVEL: i32 = 19;
+
+/// Backup metadata stored alongside backup files
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackupInfo {
+    /// Date backup was created
+    pub backup_date: DateTime<Utc>,
+    /// Whether backup is Valve stock firmware
+    pub is_valve_stock: bool,
+    /// Firmware version string
+    pub version: String,
+    /// SHA256 hashes of backup files
+    pub files: std::collections::HashMap<String, FileHash>,
+}
+
+/// File hash information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileHash {
+    pub sha256: String,
+    pub size: u64,
+}
+
+/// Backup manager
+pub struct BackupManager {
+    firmware_path: PathBuf,
+}
+
+impl BackupManager {
+    /// Create a new backup manager
+    pub fn new(firmware_path: &Path) -> Self {
+        Self {
+            firmware_path: firmware_path.to_path_buf(),
+        }
+    }
+
+    /// Check if backup files exist
+    pub fn backup_files_exist(&self) -> bool {
+        MANAGED_FILES.iter().all(|f| {
+            self.firmware_path.join(format!("{}{}", f, BACKUP_SUFFIX)).exists()
+        })
+    }
+
+    /// Get backup metadata (if exists)
+    pub fn get_backup_info(&self) -> Option<BackupInfo> {
+        let metadata_path = self.firmware_path.join(BACKUP_METADATA_FILE);
+        if !metadata_path.exists() {
+            return None;
+        }
+
+        let content = fs::read_to_string(&metadata_path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    /// Create backup of current firmware
+    pub fn create_backup(&self, current_version: &FirmwareVersion) -> Result<()> {
+        let mut files = std::collections::HashMap::new();
+
+        // Copy each managed file to backup
+        for filename in MANAGED_FILES {
+            let src = self.firmware_path.join(filename);
+            let dst = self.firmware_path.join(format!("{}{}", filename, BACKUP_SUFFIX));
+
+            if !src.exists() {
+                bail!("Cannot backup: {} not found", src.display());
+            }
+
+            // Calculate hash before copying
+            let hash = calculate_file_hash(&src)?;
+            let metadata = fs::metadata(&src)?;
+
+            fs::copy(&src, &dst)
+                .with_context(|| format!("Failed to copy {} to backup", filename))?;
+
+            files.insert(filename.to_string(), FileHash {
+                sha256: hash,
+                size: metadata.len(),
+            });
+        }
+
+        // Write metadata
+        let info = BackupInfo {
+            backup_date: Utc::now(),
+            is_valve_stock: current_version.is_valve_stock(),
+            version: current_version.version_string.clone(),
+            files,
+        };
+
+        let metadata_path = self.firmware_path.join(BACKUP_METADATA_FILE);
+        let content = serde_json::to_string_pretty(&info)?;
+        fs::write(&metadata_path, content)
+            .context("Failed to write backup metadata")?;
+
+        Ok(())
+    }
+
+    /// Verify backup integrity against stored hashes
+    pub fn verify_integrity(&self, info: &BackupInfo) -> Result<()> {
+        for (filename, expected) in &info.files {
+            let backup_path = self.firmware_path.join(format!("{}{}", filename, BACKUP_SUFFIX));
+
+            if !backup_path.exists() {
+                bail!("Backup file missing: {}", backup_path.display());
+            }
+
+            let actual_hash = calculate_file_hash(&backup_path)?;
+            if actual_hash != expected.sha256 {
+                bail!(
+                    "Backup file corrupted: {}\n  Expected: {}\n  Actual:   {}",
+                    filename, expected.sha256, actual_hash
+                );
+            }
+
+            let metadata = fs::metadata(&backup_path)?;
+            if metadata.len() != expected.size {
+                bail!(
+                    "Backup file size mismatch: {} ({} != {})",
+                    filename, metadata.len(), expected.size
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extract version from backup (when metadata is missing)
+    pub fn extract_backup_version(&self) -> Result<String> {
+        let backup_amss = self.firmware_path.join(format!("amss.bin.zst{}", BACKUP_SUFFIX));
+
+        if !backup_amss.exists() {
+            bail!("Backup amss.bin.zst not found");
+        }
+
+        // Decompress and extract version
+        let file = File::open(&backup_amss)?;
+        let decoder = zstd::stream::Decoder::new(file)?;
+
+        let mut data = Vec::new();
+        std::io::BufReader::new(decoder).read_to_end(&mut data)?;
+
+        let pattern = b"QC_IMAGE_VERSION_STRING=";
+        if let Some(pos) = data.windows(pattern.len()).position(|w| w == pattern) {
+            let start = pos + pattern.len();
+            let mut end = start;
+            while end < data.len() && data[end] >= 0x20 && data[end] < 0x7F {
+                end += 1;
+            }
+            if end > start {
+                return Ok(String::from_utf8_lossy(&data[start..end]).to_string());
+            }
+        }
+
+        bail!("Could not extract version from backup")
+    }
+}
+
+/// Firmware deployer
+pub struct FirmwareDeployer {
+    firmware_path: PathBuf,
+}
+
+impl FirmwareDeployer {
+    /// Create a new deployer
+    pub fn new(firmware_path: &Path) -> Self {
+        Self {
+            firmware_path: firmware_path.to_path_buf(),
+        }
+    }
+
+    /// Deploy firmware from staging directory
+    ///
+    /// Compresses files and copies them atomically
+    pub fn deploy(&self, staging_dir: &Path) -> Result<()> {
+        // Handle SteamOS readonly filesystem
+        let is_steamos = is_steamos();
+        if is_steamos {
+            disable_readonly()?;
+        }
+
+        let result = self.deploy_inner(staging_dir);
+
+        // Re-enable readonly even if deploy failed
+        if is_steamos {
+            if let Err(e) = enable_readonly() {
+                eprintln!("Warning: Failed to re-enable readonly: {}", e);
+            }
+        }
+
+        result
+    }
+
+    /// Inner deploy logic (separated for readonly handling)
+    fn deploy_inner(&self, staging_dir: &Path) -> Result<()> {
+        // Map of source filename (without .zst) to compressed destination
+        let files = [
+            ("amss.bin", "amss.bin.zst"),
+            ("m3.bin", "m3.bin.zst"),
+            ("board-2.bin", "board-2.bin.zst"),
+        ];
+
+        // Phase 1: Compress all files to staging with .zst extension
+        for (src_name, _dst_name) in &files {
+            let src = staging_dir.join(src_name);
+            let compressed = staging_dir.join(format!("{}.zst", src_name));
+
+            compress_file(&src, &compressed)?;
+        }
+
+        // Phase 2: Copy to firmware directory with .new suffix
+        for (_src_name, dst_name) in &files {
+            let src = staging_dir.join(format!("{}", dst_name));
+            let dst_new = self.firmware_path.join(format!("{}.new", dst_name));
+
+            fs::copy(&src, &dst_new)
+                .with_context(|| format!("Failed to copy {} to firmware directory", dst_name))?;
+        }
+
+        // Phase 3: Atomic rename .new to actual
+        for (_src_name, dst_name) in &files {
+            let dst_new = self.firmware_path.join(format!("{}.new", dst_name));
+            let dst_final = self.firmware_path.join(dst_name);
+
+            fs::rename(&dst_new, &dst_final)
+                .with_context(|| format!("Failed to rename {} to final location", dst_name))?;
+        }
+
+        Ok(())
+    }
+
+    /// Restore firmware from backup
+    pub fn restore_backup(&self) -> Result<()> {
+        // Handle SteamOS readonly filesystem
+        let is_steamos = is_steamos();
+        if is_steamos {
+            disable_readonly()?;
+        }
+
+        let result = self.restore_inner();
+
+        if is_steamos {
+            if let Err(e) = enable_readonly() {
+                eprintln!("Warning: Failed to re-enable readonly: {}", e);
+            }
+        }
+
+        result
+    }
+
+    /// Inner restore logic
+    fn restore_inner(&self) -> Result<()> {
+        // Phase 1: Copy backups to .new
+        for filename in MANAGED_FILES {
+            let backup = self.firmware_path.join(format!("{}{}", filename, BACKUP_SUFFIX));
+            let dst_new = self.firmware_path.join(format!("{}.new", filename));
+
+            if !backup.exists() {
+                bail!("Backup file not found: {}", backup.display());
+            }
+
+            fs::copy(&backup, &dst_new)
+                .with_context(|| format!("Failed to copy backup {}", filename))?;
+        }
+
+        // Phase 2: Atomic rename
+        for filename in MANAGED_FILES {
+            let dst_new = self.firmware_path.join(format!("{}.new", filename));
+            let dst_final = self.firmware_path.join(filename);
+
+            fs::rename(&dst_new, &dst_final)
+                .with_context(|| format!("Failed to restore {}", filename))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Calculate SHA256 hash of a file
+fn calculate_file_hash(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Compress a file with zstd
+fn compress_file(src: &Path, dst: &Path) -> Result<()> {
+    let input = File::open(src)
+        .with_context(|| format!("Failed to open {} for compression", src.display()))?;
+
+    let output = File::create(dst)
+        .with_context(|| format!("Failed to create {}", dst.display()))?;
+
+    let mut encoder = zstd::stream::Encoder::new(output, ZSTD_COMPRESSION_LEVEL)?;
+
+    std::io::copy(&mut std::io::BufReader::new(input), &mut encoder)?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+/// Check if running on SteamOS
+fn is_steamos() -> bool {
+    if let Ok(content) = fs::read_to_string("/etc/os-release") {
+        content.contains("ID=steamos")
+    } else {
+        false
+    }
+}
+
+/// Disable SteamOS readonly filesystem
+fn disable_readonly() -> Result<()> {
+    // Check if steamos-readonly command exists
+    if !Path::new("/usr/bin/steamos-readonly").exists() {
+        return Ok(());  // Not SteamOS or command not available
+    }
+
+    let output = Command::new("steamos-readonly")
+        .arg("disable")
+        .output()
+        .context("Failed to run steamos-readonly disable")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Ignore "already disabled" type errors
+        if !stderr.contains("already") && !output.status.success() {
+            bail!("Failed to disable readonly mode: {}", stderr);
+        }
+    }
+
+    Ok(())
+}
+
+/// Enable SteamOS readonly filesystem
+fn enable_readonly() -> Result<()> {
+    if !Path::new("/usr/bin/steamos-readonly").exists() {
+        return Ok(());
+    }
+
+    let output = Command::new("steamos-readonly")
+        .arg("enable")
+        .output()
+        .context("Failed to run steamos-readonly enable")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to enable readonly mode: {}", stderr);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_steamos() {
+        // This will return false on non-SteamOS systems
+        let result = is_steamos();
+        println!("Is SteamOS: {}", result);
+    }
+}

--- a/src/firmware/deploy.rs
+++ b/src/firmware/deploy.rs
@@ -345,7 +345,7 @@ fn compress_file(src: &Path, dst: &Path) -> Result<()> {
 }
 
 /// Check if running on SteamOS
-fn is_steamos() -> bool {
+pub fn is_steamos() -> bool {
     if let Ok(content) = fs::read_to_string("/etc/os-release") {
         content.contains("ID=steamos")
     } else {
@@ -354,7 +354,7 @@ fn is_steamos() -> bool {
 }
 
 /// Disable SteamOS readonly filesystem
-fn disable_readonly() -> Result<()> {
+pub fn disable_readonly() -> Result<()> {
     // Check if steamos-readonly command exists
     if !Path::new("/usr/bin/steamos-readonly").exists() {
         return Ok(());  // Not SteamOS or command not available
@@ -377,7 +377,7 @@ fn disable_readonly() -> Result<()> {
 }
 
 /// Enable SteamOS readonly filesystem
-fn enable_readonly() -> Result<()> {
+pub fn enable_readonly() -> Result<()> {
     if !Path::new("/usr/bin/steamos-readonly").exists() {
         return Ok(());
     }

--- a/src/firmware/device.rs
+++ b/src/firmware/device.rs
@@ -21,7 +21,6 @@ pub struct DeviceInfo {
     // DMI info
     pub board_vendor: Option<String>,
     pub board_name: Option<String>,
-    pub product_name: Option<String>,
 
     // WiFi PCI IDs
     pub wifi_vendor: Option<String>,
@@ -39,7 +38,6 @@ impl DeviceInfo {
     pub fn detect() -> Self {
         let board_vendor = read_dmi("board_vendor");
         let board_name = read_dmi("board_name");
-        let product_name = read_dmi("product_name");
 
         // Try to find WiFi device - prefer wlan0, fall back to scanning
         let wifi_path = find_wifi_device_path();
@@ -69,7 +67,6 @@ impl DeviceInfo {
         Self {
             board_vendor,
             board_name,
-            product_name,
             wifi_vendor,
             wifi_device,
             wifi_subsys_vendor,
@@ -82,11 +79,6 @@ impl DeviceInfo {
     /// Check if this is a supported device (Steam Deck OLED with QCA2066)
     pub fn is_supported(&self) -> bool {
         self.dmi_valid && self.wifi_valid
-    }
-
-    /// Check if DMI indicates Steam Deck OLED
-    pub fn is_steam_deck_oled(&self) -> bool {
-        self.dmi_valid
     }
 
     /// Check if WiFi card is the supported QCA2066 variant

--- a/src/firmware/device.rs
+++ b/src/firmware/device.rs
@@ -1,0 +1,174 @@
+//! Hardware detection and validation for Steam Deck OLED
+//!
+//! This module implements the two-layer hardware gate:
+//! 1. DMI check: Valve + Galileo (Steam Deck OLED only)
+//! 2. PCI ID check: 17cb:1103 with subsystem 17cb:0108 (QCA2066 exact variant)
+
+use std::fs;
+use std::path::Path;
+
+/// Expected values for Steam Deck OLED
+const EXPECTED_BOARD_VENDOR: &str = "Valve";
+const EXPECTED_BOARD_NAME: &str = "Galileo";  // OLED = Galileo, LCD = Jupiter
+const EXPECTED_WIFI_VENDOR: &str = "0x17cb";  // Qualcomm
+const EXPECTED_WIFI_DEVICE: &str = "0x1103";  // QCNFA765 / QCA2066
+const EXPECTED_WIFI_SUBSYS_VENDOR: &str = "0x17cb";
+const EXPECTED_WIFI_SUBSYS_DEVICE: &str = "0x0108";
+
+/// Detected device information
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+    // DMI info
+    pub board_vendor: Option<String>,
+    pub board_name: Option<String>,
+    pub product_name: Option<String>,
+
+    // WiFi PCI IDs
+    pub wifi_vendor: Option<String>,
+    pub wifi_device: Option<String>,
+    pub wifi_subsys_vendor: Option<String>,
+    pub wifi_subsys_device: Option<String>,
+
+    // Derived flags
+    dmi_valid: bool,
+    wifi_valid: bool,
+}
+
+impl DeviceInfo {
+    /// Detect device information from sysfs
+    pub fn detect() -> Self {
+        let board_vendor = read_dmi("board_vendor");
+        let board_name = read_dmi("board_name");
+        let product_name = read_dmi("product_name");
+
+        // Try to find WiFi device - prefer wlan0, fall back to scanning
+        let wifi_path = find_wifi_device_path();
+
+        let (wifi_vendor, wifi_device, wifi_subsys_vendor, wifi_subsys_device) =
+            if let Some(path) = wifi_path {
+                (
+                    read_sysfs(&path.join("vendor")),
+                    read_sysfs(&path.join("device")),
+                    read_sysfs(&path.join("subsystem_vendor")),
+                    read_sysfs(&path.join("subsystem_device")),
+                )
+            } else {
+                (None, None, None, None)
+            };
+
+        // Validate DMI
+        let dmi_valid = board_vendor.as_deref() == Some(EXPECTED_BOARD_VENDOR)
+            && board_name.as_deref() == Some(EXPECTED_BOARD_NAME);
+
+        // Validate WiFi PCI IDs
+        let wifi_valid = wifi_vendor.as_deref() == Some(EXPECTED_WIFI_VENDOR)
+            && wifi_device.as_deref() == Some(EXPECTED_WIFI_DEVICE)
+            && wifi_subsys_vendor.as_deref() == Some(EXPECTED_WIFI_SUBSYS_VENDOR)
+            && wifi_subsys_device.as_deref() == Some(EXPECTED_WIFI_SUBSYS_DEVICE);
+
+        Self {
+            board_vendor,
+            board_name,
+            product_name,
+            wifi_vendor,
+            wifi_device,
+            wifi_subsys_vendor,
+            wifi_subsys_device,
+            dmi_valid,
+            wifi_valid,
+        }
+    }
+
+    /// Check if this is a supported device (Steam Deck OLED with QCA2066)
+    pub fn is_supported(&self) -> bool {
+        self.dmi_valid && self.wifi_valid
+    }
+
+    /// Check if DMI indicates Steam Deck OLED
+    pub fn is_steam_deck_oled(&self) -> bool {
+        self.dmi_valid
+    }
+
+    /// Check if WiFi card is the supported QCA2066 variant
+    pub fn is_wifi_supported(&self) -> bool {
+        self.wifi_valid
+    }
+}
+
+/// Read a DMI attribute from sysfs
+fn read_dmi(attr: &str) -> Option<String> {
+    let path = format!("/sys/class/dmi/id/{}", attr);
+    read_sysfs(Path::new(&path))
+}
+
+/// Read a sysfs file, returning trimmed contents
+fn read_sysfs(path: &Path) -> Option<String> {
+    fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Find the WiFi device path in sysfs
+///
+/// Tries wlan0 first (most common), then scans for ath11k devices
+fn find_wifi_device_path() -> Option<std::path::PathBuf> {
+    // Try wlan0 first (standard interface name)
+    let wlan0_path = Path::new("/sys/class/net/wlan0/device");
+    if wlan0_path.exists() {
+        return Some(wlan0_path.to_path_buf());
+    }
+
+    // Try wlp* interfaces (some distros use predictable names)
+    if let Ok(entries) = fs::read_dir("/sys/class/net") {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with("wl") {
+                let device_path = entry.path().join("device");
+                if device_path.exists() {
+                    // Verify it's an ath11k device
+                    let driver_link = device_path.join("driver");
+                    if let Ok(driver_target) = fs::read_link(&driver_link) {
+                        let driver_name = driver_target.file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default();
+                        if driver_name.contains("ath11k") {
+                            return Some(device_path);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Scan PCI bus for Qualcomm 17cb:1103
+    if let Ok(entries) = fs::read_dir("/sys/bus/pci/devices") {
+        for entry in entries.flatten() {
+            let device_path = entry.path();
+            let vendor = read_sysfs(&device_path.join("vendor"));
+            let device = read_sysfs(&device_path.join("device"));
+
+            if vendor.as_deref() == Some(EXPECTED_WIFI_VENDOR)
+                && device.as_deref() == Some(EXPECTED_WIFI_DEVICE)
+            {
+                return Some(device_path);
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_device_detection() {
+        // This will work on any system, just may not be a Steam Deck
+        let device = DeviceInfo::detect();
+        println!("Detected device: {:?}", device);
+        println!("Is supported: {}", device.is_supported());
+    }
+}

--- a/src/firmware/download.rs
+++ b/src/firmware/download.rs
@@ -67,7 +67,7 @@ impl FirmwareDownloader {
             .prefix("hifi-firmware-")
             .tempdir()
             .context("Failed to create staging directory")?
-            .into_path();
+            .keep();
 
         for file in FIRMWARE_FILES {
             self.download_file(file, &staging_dir)?;

--- a/src/firmware/download.rs
+++ b/src/firmware/download.rs
@@ -1,0 +1,173 @@
+//! Firmware download from linux-firmware.git
+//!
+//! Downloads firmware files from GitLab and validates them before deployment.
+
+use anyhow::{Result, Context, bail};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::firmware::version::FirmwareVersion;
+
+/// Base URL for linux-firmware.git raw files
+const FIRMWARE_BASE_URL: &str = "https://gitlab.com/kernel-firmware/linux-firmware/-/raw/main/ath11k/QCA2066/hw2.1";
+
+/// Firmware files to download
+const FIRMWARE_FILES: &[FirmwareFile] = &[
+    FirmwareFile {
+        name: "amss.bin",
+        min_size: 5_000_000,  // ~5.3MB actual
+        description: "Main WiFi firmware",
+    },
+    FirmwareFile {
+        name: "m3.bin",
+        min_size: 200_000,    // ~260KB actual
+        description: "M3 microcontroller firmware",
+    },
+    FirmwareFile {
+        name: "board-2.bin",
+        min_size: 500_000,    // ~745KB actual
+        description: "Board configuration data",
+    },
+];
+
+/// Firmware file metadata
+struct FirmwareFile {
+    name: &'static str,
+    min_size: u64,
+    description: &'static str,
+}
+
+/// Firmware downloader
+pub struct FirmwareDownloader {
+    client: reqwest::blocking::Client,
+}
+
+impl FirmwareDownloader {
+    /// Create a new downloader
+    pub fn new() -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))  // 2 min timeout for large files
+            .user_agent("hifi-wifi/3.0")
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self { client })
+    }
+
+    /// Download all firmware files to a staging directory
+    ///
+    /// Returns the path to the staging directory on success
+    pub fn download_all(&self) -> Result<PathBuf> {
+        // Create staging directory
+        let staging_dir = tempfile::Builder::new()
+            .prefix("hifi-firmware-")
+            .tempdir()
+            .context("Failed to create staging directory")?
+            .into_path();
+
+        for file in FIRMWARE_FILES {
+            self.download_file(file, &staging_dir)?;
+        }
+
+        Ok(staging_dir)
+    }
+
+    /// Download a single firmware file
+    fn download_file(&self, file: &FirmwareFile, staging_dir: &Path) -> Result<()> {
+        let url = format!("{}/{}", FIRMWARE_BASE_URL, file.name);
+        let dest_path = staging_dir.join(file.name);
+
+        print!("  Downloading {}... ", file.name);
+        std::io::stdout().flush().ok();
+
+        let response = self.client
+            .get(&url)
+            .send()
+            .with_context(|| format!("Failed to fetch {}", file.name))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            println!("FAILED");
+            bail!("Failed to download {}: HTTP {}", file.name, status);
+        }
+
+        // Download to file
+        let bytes = response.bytes()
+            .with_context(|| format!("Failed to read {} response", file.name))?;
+
+        // Validate size
+        let size = bytes.len() as u64;
+        if size < file.min_size {
+            println!("FAILED");
+            bail!(
+                "Downloaded {} is too small ({} bytes, expected >= {}). File may be corrupted.",
+                file.name, size, file.min_size
+            );
+        }
+
+        // Write to staging
+        let mut dest_file = File::create(&dest_path)
+            .with_context(|| format!("Failed to create {}", dest_path.display()))?;
+
+        dest_file.write_all(&bytes)
+            .with_context(|| format!("Failed to write {}", dest_path.display()))?;
+
+        let size_mb = size as f64 / 1_000_000.0;
+        println!("{:.1} MB", size_mb);
+
+        Ok(())
+    }
+
+    /// Validate downloaded firmware files
+    ///
+    /// Checks file sizes and verifies we can extract version from amss.bin
+    pub fn validate(&self, staging_dir: &Path) -> Result<()> {
+        // Verify all files exist and have reasonable sizes
+        for file in FIRMWARE_FILES {
+            let path = staging_dir.join(file.name);
+            let metadata = fs::metadata(&path)
+                .with_context(|| format!("Missing file: {}", file.name))?;
+
+            if metadata.len() < file.min_size {
+                bail!(
+                    "{} is too small ({} bytes, expected >= {})",
+                    file.name, metadata.len(), file.min_size
+                );
+            }
+
+            print!("  Validating {}... ", file.name);
+            println!("OK ({} bytes)", metadata.len());
+        }
+
+        // Verify we can extract version from amss.bin (proves it's valid firmware)
+        print!("  Extracting version... ");
+        let amss_path = staging_dir.join("amss.bin");
+        let version = FirmwareVersion::from_raw(&amss_path)
+            .context("Failed to extract version from downloaded firmware")?;
+
+        if !version.version_string.contains("WLAN") {
+            bail!("Downloaded firmware has unexpected version format: {}", version.version_string);
+        }
+
+        println!("{}", version.version_string);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore]  // Requires network access
+    fn test_download() {
+        let downloader = FirmwareDownloader::new().unwrap();
+        let staging = downloader.download_all().unwrap();
+        downloader.validate(&staging).unwrap();
+
+        // Cleanup
+        fs::remove_dir_all(&staging).ok();
+    }
+}

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -12,7 +12,7 @@ pub mod version;
 pub mod download;
 pub mod deploy;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, bail, Context};
 use clap::Subcommand;
 
 use crate::firmware::device::DeviceInfo;

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -1,0 +1,507 @@
+//! Firmware update module for Steam Deck OLED WiFi (QCA2066/ath11k)
+//!
+//! This module provides firmware management capabilities:
+//! - `status`: Show current vs latest available firmware version
+//! - `update`: Download and install latest upstream firmware from linux-firmware.git
+//! - `revert`: Restore original stock firmware from backup
+//!
+//! **Hardware gate**: Only runs on Steam Deck OLED (Galileo) with QCA2066 WiFi card.
+
+pub mod device;
+pub mod version;
+pub mod download;
+pub mod deploy;
+
+use anyhow::{Result, bail};
+use clap::Subcommand;
+
+use crate::firmware::device::DeviceInfo;
+use crate::firmware::version::{FirmwareVersion, get_upstream_version};
+use crate::firmware::deploy::{BackupManager, FirmwareDeployer};
+use crate::firmware::download::FirmwareDownloader;
+
+/// Firmware subcommands
+#[derive(Subcommand, Clone)]
+pub enum FirmwareAction {
+    /// Show current and latest available firmware version
+    Status {
+        /// Output as JSON for scripting
+        #[arg(long)]
+        json: bool,
+        /// Skip fetching upstream version (offline mode)
+        #[arg(long)]
+        offline: bool,
+    },
+    /// Download and install latest upstream firmware
+    Update {
+        /// Skip confirmation prompts
+        #[arg(long, short = 'y')]
+        force: bool,
+    },
+    /// Revert to original stock firmware from backup
+    Revert {
+        /// Skip confirmation prompts
+        #[arg(long, short = 'y')]
+        force: bool,
+    },
+}
+
+/// Main entry point for firmware commands
+pub fn run_firmware(action: FirmwareAction, dry_run: bool) -> Result<()> {
+    match action {
+        FirmwareAction::Status { json, offline } => run_status(json, offline),
+        FirmwareAction::Update { force } => run_update(force, dry_run),
+        FirmwareAction::Revert { force } => run_revert(force, dry_run),
+    }
+}
+
+/// ANSI color codes
+mod colors {
+    pub const RED: &str = "\x1b[0;31m";
+    pub const GREEN: &str = "\x1b[0;32m";
+    pub const YELLOW: &str = "\x1b[0;33m";
+    pub const CYAN: &str = "\x1b[0;36m";
+    pub const BOLD: &str = "\x1b[1m";
+    pub const DIM: &str = "\x1b[2m";
+    pub const NC: &str = "\x1b[0m";
+}
+
+/// Run firmware status check
+fn run_status(json: bool, offline: bool) -> Result<()> {
+    use colors::*;
+
+    // Detect device (informational only for status - don't gate)
+    let device = DeviceInfo::detect();
+
+    // Get firmware path and current version
+    let firmware_path = version::detect_firmware_path()?;
+    let current = FirmwareVersion::from_installed(&firmware_path)?;
+
+    // Check for interrupted update
+    let health_warnings = check_health(&firmware_path);
+
+    // Get upstream version (unless offline mode)
+    let upstream = if offline {
+        None
+    } else {
+        match get_upstream_version() {
+            Ok(v) => Some(v),
+            Err(e) => {
+                if !json {
+                    eprintln!("{}Warning:{} Could not fetch upstream version: {}", YELLOW, NC, e);
+                }
+                None
+            }
+        }
+    };
+
+    // Check backup status
+    let backup_mgr = BackupManager::new(&firmware_path);
+    let backup_info = backup_mgr.get_backup_info();
+
+    if json {
+        // JSON output for scripting
+        let output = serde_json::json!({
+            "device": {
+                "supported": device.is_supported(),
+                "board_vendor": device.board_vendor,
+                "board_name": device.board_name,
+                "wifi_vendor": device.wifi_vendor,
+                "wifi_device": device.wifi_device,
+            },
+            "firmware": {
+                "path": firmware_path.to_string_lossy(),
+                "current_version": current.version_string,
+                "is_valve_stock": current.is_valve_stock(),
+            },
+            "upstream": upstream.as_ref().map(|u| &u.version_string),
+            "backup": backup_info.as_ref().map(|b| serde_json::json!({
+                "version": b.version,
+                "date": b.backup_date.to_rfc3339(),
+                "is_valve_stock": b.is_valve_stock,
+            })),
+            "update_available": upstream.as_ref().map(|u| u.version_string != current.version_string),
+            "health_warnings": health_warnings,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    // Human-readable output
+    println!();
+    println!("{}{}WiFi Firmware Status{}", BOLD, CYAN, NC);
+    println!("{}═══════════════════════════════════════{}", CYAN, NC);
+    println!();
+
+    // Device info
+    if device.is_supported() {
+        println!("{}Device:{}\t\tSteam Deck OLED (Galileo) {}✓{}", BOLD, NC, GREEN, NC);
+    } else {
+        println!("{}Device:{}\t\t{} {} {}[Not Supported]{}", BOLD, NC,
+                 device.board_vendor.as_deref().unwrap_or("Unknown"),
+                 device.board_name.as_deref().unwrap_or("Unknown"),
+                 RED, NC);
+    }
+
+    // WiFi card info
+    if device.is_wifi_supported() {
+        println!("{}WiFi Card:{}\t\tQCA2066 (17cb:1103) {}✓{}", BOLD, NC, GREEN, NC);
+    } else {
+        println!("{}WiFi Card:{}\t\t{}:{} {}[Not Supported]{}", BOLD, NC,
+                 device.wifi_vendor.as_deref().unwrap_or("????"),
+                 device.wifi_device.as_deref().unwrap_or("????"),
+                 RED, NC);
+    }
+
+    println!("{}Firmware Path:{}\t{}", BOLD, NC, firmware_path.display());
+    println!();
+
+    // Health warnings
+    for warning in &health_warnings {
+        println!("{}⚠ Warning:{} {}", YELLOW, NC, warning);
+    }
+    if !health_warnings.is_empty() {
+        println!();
+    }
+
+    // Version info
+    let stock_indicator = if current.is_valve_stock() {
+        format!(" {}(Valve stock){}", DIM, NC)
+    } else {
+        format!(" {}(upstream){}", DIM, NC)
+    };
+    println!("{}Current:{}\t\t{}{}", BOLD, NC, current.version_string, stock_indicator);
+
+    if let Some(ref upstream_ver) = upstream {
+        println!("{}Latest upstream:{}\t{}", BOLD, NC, upstream_ver.version_string);
+
+        // Status
+        if upstream_ver.version_string == current.version_string {
+            println!("{}Status:{}\t\t{}Up to date{}", BOLD, NC, GREEN, NC);
+        } else if current.is_valve_stock() {
+            println!("{}Status:{}\t\t{}Update available{}", BOLD, NC, YELLOW, NC);
+        } else {
+            // Already on upstream but different version
+            println!("{}Status:{}\t\t{}Newer version available{}", BOLD, NC, YELLOW, NC);
+        }
+    }
+
+    // Backup info
+    if let Some(ref backup) = backup_info {
+        let stock_str = if backup.is_valve_stock { " (Valve stock)" } else { "" };
+        println!("{}Backup:{}\t\t{}{} ({})", BOLD, NC, backup.version, stock_str,
+                 backup.backup_date.format("%Y-%m-%d"));
+    } else {
+        println!("{}Backup:{}\t\t{}None{}", BOLD, NC, DIM, NC);
+    }
+
+    println!();
+
+    // Helpful hints
+    if !device.is_supported() {
+        println!("{}Note:{} Firmware updates are only available on Steam Deck OLED.", DIM, NC);
+    } else if upstream.as_ref().map(|u| u.version_string != current.version_string).unwrap_or(false) {
+        println!("{}Tip:{} Run 'sudo hifi-wifi firmware update' to install the latest firmware.", DIM, NC);
+    }
+
+    Ok(())
+}
+
+/// Check for health issues (interrupted updates, missing files, etc.)
+fn check_health(firmware_path: &std::path::Path) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    // Check for .new files (interrupted update)
+    for file in &["amss.bin.zst.new", "m3.bin.zst.new", "board-2.bin.zst.new"] {
+        if firmware_path.join(file).exists() {
+            warnings.push("Interrupted update detected. Run 'hifi-wifi firmware update' to complete.".to_string());
+            break;
+        }
+    }
+
+    // Check for backup without metadata
+    let backup_mgr = BackupManager::new(firmware_path);
+    if backup_mgr.backup_files_exist() && backup_mgr.get_backup_info().is_none() {
+        warnings.push("Backup metadata missing. Integrity cannot be verified.".to_string());
+    }
+
+    warnings
+}
+
+/// Run firmware update
+fn run_update(force: bool, dry_run: bool) -> Result<()> {
+    use colors::*;
+
+    println!();
+    println!("{}{}WiFi Firmware Update{}", BOLD, CYAN, NC);
+    println!("{}═══════════════════════════════════════{}", CYAN, NC);
+    println!();
+
+    // Phase 1: Pre-flight checks
+    println!("{}[1/5]{} Pre-flight checks...", DIM, NC);
+
+    // Hardware gate
+    let device = DeviceInfo::detect();
+    if !device.is_supported() {
+        bail!(
+            "Firmware updates are only supported on Steam Deck OLED (Galileo) with QCA2066 WiFi.\n\
+             Detected device: {} {}\n\
+             Detected WiFi:   {}:{} (subsystem {}:{})",
+            device.board_vendor.as_deref().unwrap_or("Unknown"),
+            device.board_name.as_deref().unwrap_or("Unknown"),
+            device.wifi_vendor.as_deref().unwrap_or("????"),
+            device.wifi_device.as_deref().unwrap_or("????"),
+            device.wifi_subsys_vendor.as_deref().unwrap_or("????"),
+            device.wifi_subsys_device.as_deref().unwrap_or("????"),
+        );
+    }
+    println!("  Device: Steam Deck OLED {}✓{}", GREEN, NC);
+    println!("  WiFi:   QCA2066 (17cb:1103) {}✓{}", GREEN, NC);
+
+    // Firmware path
+    let firmware_path = version::detect_firmware_path()?;
+    println!("  Path:   {} {}✓{}", firmware_path.display(), GREEN, NC);
+
+    // Current version
+    let current = FirmwareVersion::from_installed(&firmware_path)?;
+    println!("  Current: {}", current.version_string);
+
+    // Upstream version
+    let upstream = get_upstream_version()?;
+    println!("  Latest:  {}", upstream.version_string);
+
+    // Check if update needed
+    if current.version_string == upstream.version_string && !force {
+        println!();
+        println!("{}Already running the latest firmware. Nothing to do.{}", GREEN, NC);
+        return Ok(());
+    }
+
+    // Check disk space (need ~25MB)
+    check_disk_space(&firmware_path, 25 * 1024 * 1024)?;
+    println!("  Disk:   Sufficient space {}✓{}", GREEN, NC);
+
+    if dry_run {
+        println!();
+        println!("{}[DRY-RUN]{} Would download and install firmware.", YELLOW, NC);
+        println!("  Files: amss.bin, m3.bin, board-2.bin");
+        println!("  From:  linux-firmware.git (GitLab)");
+        return Ok(());
+    }
+
+    // Phase 2: Download to staging
+    println!();
+    println!("{}[2/5]{} Downloading firmware...", DIM, NC);
+
+    let downloader = FirmwareDownloader::new()?;
+    let staging_dir = downloader.download_all()?;
+    println!("  Downloaded to staging {}✓{}", GREEN, NC);
+
+    // Validate downloads
+    println!();
+    println!("{}[3/5]{} Validating downloads...", DIM, NC);
+    downloader.validate(&staging_dir)?;
+    println!("  All files validated {}✓{}", GREEN, NC);
+
+    // Phase 3: Backup (if needed)
+    println!();
+    println!("{}[4/5]{} Managing backup...", DIM, NC);
+
+    let backup_mgr = BackupManager::new(&firmware_path);
+    if !backup_mgr.backup_files_exist() {
+        // First update - create backup
+        if !current.is_valve_stock() && !force {
+            println!();
+            println!("{}Warning:{} Current firmware is not Valve stock.", YELLOW, NC);
+            println!("  Current: {}", current.version_string);
+            println!("  Expected: CI_WLAN.HSP.1.1-... (Valve prefix)");
+            println!();
+            println!("Creating backup of current (modified) state. To restore true Valve");
+            println!("stock firmware, use SteamOS recovery or reinstall.");
+            println!();
+
+            if !confirm("Continue with backup and update?")? {
+                bail!("Update cancelled by user.");
+            }
+        }
+
+        backup_mgr.create_backup(&current)?;
+        println!("  Backup created {}✓{}", GREEN, NC);
+    } else {
+        println!("  Backup already exists {}✓{}", GREEN, NC);
+    }
+
+    // Phase 4: Deploy
+    println!();
+    println!("{}[5/5]{} Deploying firmware...", DIM, NC);
+
+    let deployer = FirmwareDeployer::new(&firmware_path);
+    deployer.deploy(&staging_dir)?;
+    println!("  Firmware deployed {}✓{}", GREEN, NC);
+
+    // Verify
+    let new_version = FirmwareVersion::from_installed(&firmware_path)?;
+
+    // Cleanup staging
+    let _ = std::fs::remove_dir_all(&staging_dir);
+
+    println!();
+    println!("{}═══════════════════════════════════════{}", GREEN, NC);
+    println!("{}Firmware updated successfully!{}", GREEN, NC);
+    println!("  Previous: {}", current.version_string);
+    println!("  Current:  {}", new_version.version_string);
+    println!();
+    println!("{}⚠ Reboot required to load new firmware.{}", YELLOW, NC);
+
+    Ok(())
+}
+
+/// Run firmware revert
+fn run_revert(force: bool, dry_run: bool) -> Result<()> {
+    use colors::*;
+
+    println!();
+    println!("{}{}WiFi Firmware Revert{}", BOLD, CYAN, NC);
+    println!("{}═══════════════════════════════════════{}", CYAN, NC);
+    println!();
+
+    // Hardware gate
+    let device = DeviceInfo::detect();
+    if !device.is_supported() {
+        bail!(
+            "Firmware management is only supported on Steam Deck OLED (Galileo) with QCA2066 WiFi.\n\
+             Detected device: {} {}",
+            device.board_vendor.as_deref().unwrap_or("Unknown"),
+            device.board_name.as_deref().unwrap_or("Unknown"),
+        );
+    }
+
+    // Get paths and versions
+    let firmware_path = version::detect_firmware_path()?;
+    let current = FirmwareVersion::from_installed(&firmware_path)?;
+
+    // Check backup exists
+    let backup_mgr = BackupManager::new(&firmware_path);
+    let backup_info = backup_mgr.get_backup_info();
+
+    if !backup_mgr.backup_files_exist() {
+        bail!(
+            "No backup found. Cannot revert.\n\n\
+             This can happen if:\n\
+               - You haven't run 'hifi-wifi firmware update' yet\n\
+               - The backup files were deleted\n\n\
+             To restore Valve stock firmware, use SteamOS recovery or reinstall."
+        );
+    }
+
+    // Get backup version
+    let backup_version = if let Some(ref info) = backup_info {
+        info.version.clone()
+    } else {
+        // No metadata - try to extract version from backup
+        backup_mgr.extract_backup_version()?
+    };
+
+    // Check if already on backup version
+    if current.version_string == backup_version && !force {
+        println!("{}Already running backup firmware. Nothing to revert.{}", GREEN, NC);
+        return Ok(());
+    }
+
+    // Verify backup integrity (if metadata exists)
+    if let Some(ref info) = backup_info {
+        println!("{}[1/3]{} Verifying backup integrity...", DIM, NC);
+        backup_mgr.verify_integrity(info)?;
+        println!("  Backup verified {}✓{}", GREEN, NC);
+    } else {
+        println!("{}[1/3]{} {}Warning:{} No backup metadata. Cannot verify integrity.", DIM, NC, YELLOW, NC);
+    }
+
+    // Confirm
+    if !force && !dry_run {
+        println!();
+        let stock_str = backup_info.as_ref()
+            .map(|i| if i.is_valve_stock { " (Valve stock)" } else { "" })
+            .unwrap_or("");
+        let date_str = backup_info.as_ref()
+            .map(|i| format!(" from {}", i.backup_date.format("%Y-%m-%d")))
+            .unwrap_or_default();
+
+        println!("Current firmware:  {}", current.version_string);
+        println!("Backup firmware:   {}{}{}", backup_version, stock_str, date_str);
+        println!();
+
+        if !confirm("Revert to backup firmware?")? {
+            bail!("Revert cancelled by user.");
+        }
+    }
+
+    if dry_run {
+        println!();
+        println!("{}[DRY-RUN]{} Would restore firmware from backup.", YELLOW, NC);
+        return Ok(());
+    }
+
+    // Restore
+    println!();
+    println!("{}[2/3]{} Restoring firmware...", DIM, NC);
+
+    let deployer = FirmwareDeployer::new(&firmware_path);
+    deployer.restore_backup()?;
+    println!("  Firmware restored {}✓{}", GREEN, NC);
+
+    // Verify
+    println!();
+    println!("{}[3/3]{} Verifying restoration...", DIM, NC);
+    let new_version = FirmwareVersion::from_installed(&firmware_path)?;
+    println!("  Version: {} {}✓{}", new_version.version_string, GREEN, NC);
+
+    println!();
+    println!("{}═══════════════════════════════════════{}", GREEN, NC);
+    println!("{}Firmware reverted successfully!{}", GREEN, NC);
+    println!("  Previous: {}", current.version_string);
+    println!("  Current:  {}", new_version.version_string);
+    println!();
+    println!("{}⚠ Reboot required to load restored firmware.{}", YELLOW, NC);
+
+    Ok(())
+}
+
+/// Check if there's enough disk space
+fn check_disk_space(path: &std::path::Path, required_bytes: u64) -> Result<()> {
+    use std::process::Command;
+
+    // Use df to get available space
+    let output = Command::new("df")
+        .args(["--output=avail", "-B1", path.to_str().unwrap_or("/lib/firmware")])
+        .output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let available: u64 = stdout.lines()
+        .nth(1)  // Skip header
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0);
+
+    if available < required_bytes {
+        bail!(
+            "Insufficient disk space. Need {} MB, have {} MB.",
+            required_bytes / (1024 * 1024),
+            available / (1024 * 1024)
+        );
+    }
+
+    Ok(())
+}
+
+/// Prompt for yes/no confirmation
+fn confirm(prompt: &str) -> Result<bool> {
+    use std::io::{self, Write};
+
+    print!("{} [y/N] ", prompt);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    Ok(input.trim().eq_ignore_ascii_case("y") || input.trim().eq_ignore_ascii_case("yes"))
+}

--- a/src/firmware/version.rs
+++ b/src/firmware/version.rs
@@ -42,11 +42,6 @@ impl FirmwareVersion {
     pub fn is_valve_stock(&self) -> bool {
         self.version_string.starts_with("CI_WLAN")
     }
-
-    /// Check if this is upstream firmware (no CI_ prefix)
-    pub fn is_upstream(&self) -> bool {
-        self.version_string.starts_with("WLAN") && !self.version_string.starts_with("CI_WLAN")
-    }
 }
 
 /// Detect the firmware path for the QCA2066/ath11k device
@@ -206,12 +201,10 @@ mod tests {
             version_string: "CI_WLAN.HSP.1.1-03926.9.1-QCAHSPSWPL_V2_SILICONZ_CE-15".to_string(),
         };
         assert!(valve.is_valve_stock());
-        assert!(!valve.is_upstream());
 
         let upstream = FirmwareVersion {
             version_string: "WLAN.HSP.1.1-03926.13-QCAHSPSWPL_V2_SILICONZ_CE-2.52297.9".to_string(),
         };
         assert!(!upstream.is_valve_stock());
-        assert!(upstream.is_upstream());
     }
 }

--- a/src/firmware/version.rs
+++ b/src/firmware/version.rs
@@ -1,0 +1,213 @@
+//! Firmware version detection and comparison
+//!
+//! Handles extracting version strings from firmware binaries and
+//! fetching the latest upstream version from linux-firmware.git
+
+use anyhow::{Result, Context, bail};
+use std::fs::File;
+use std::io::{Read, BufReader};
+use std::path::{Path, PathBuf};
+
+/// Firmware version information
+#[derive(Debug, Clone)]
+pub struct FirmwareVersion {
+    /// Full version string (e.g., "WLAN.HSP.1.1-03926.13-QCAHSPSWPL_V2_SILICONZ_CE-2.52297.9")
+    pub version_string: String,
+}
+
+impl FirmwareVersion {
+    /// Extract version from an installed firmware file
+    ///
+    /// Decompresses amss.bin.zst and searches for the QC_IMAGE_VERSION_STRING
+    pub fn from_installed(firmware_path: &Path) -> Result<Self> {
+        let amss_path = firmware_path.join("amss.bin.zst");
+
+        if !amss_path.exists() {
+            bail!("Firmware file not found: {}", amss_path.display());
+        }
+
+        // Decompress and extract version
+        let version_string = extract_version_from_zst(&amss_path)?;
+
+        Ok(Self { version_string })
+    }
+
+    /// Extract version from an uncompressed firmware file
+    pub fn from_raw(amss_path: &Path) -> Result<Self> {
+        let version_string = extract_version_from_raw(amss_path)?;
+        Ok(Self { version_string })
+    }
+
+    /// Check if this is Valve stock firmware (has CI_WLAN prefix)
+    pub fn is_valve_stock(&self) -> bool {
+        self.version_string.starts_with("CI_WLAN")
+    }
+
+    /// Check if this is upstream firmware (no CI_ prefix)
+    pub fn is_upstream(&self) -> bool {
+        self.version_string.starts_with("WLAN") && !self.version_string.starts_with("CI_WLAN")
+    }
+}
+
+/// Detect the firmware path for the QCA2066/ath11k device
+///
+/// Checks multiple possible paths (SteamOS uses QCA206X, upstream uses QCA2066)
+pub fn detect_firmware_path() -> Result<PathBuf> {
+    // Valve/SteamOS path (most likely on Steam Deck)
+    let valve_path = Path::new("/lib/firmware/ath11k/QCA206X/hw2.1");
+    if valve_path.exists() && valve_path.join("amss.bin.zst").exists() {
+        return Ok(valve_path.to_path_buf());
+    }
+
+    // Upstream linux-firmware path
+    let upstream_path = Path::new("/lib/firmware/ath11k/QCA2066/hw2.1");
+    if upstream_path.exists() && upstream_path.join("amss.bin.zst").exists() {
+        return Ok(upstream_path.to_path_buf());
+    }
+
+    // Generic WCN6855 path (same chip, different name)
+    let generic_path = Path::new("/lib/firmware/ath11k/WCN6855/hw2.1");
+    if generic_path.exists() && generic_path.join("amss.bin.zst").exists() {
+        return Ok(generic_path.to_path_buf());
+    }
+
+    // Also check hw2.0 variants
+    let generic_path_20 = Path::new("/lib/firmware/ath11k/WCN6855/hw2.0");
+    if generic_path_20.exists() && generic_path_20.join("amss.bin.zst").exists() {
+        return Ok(generic_path_20.to_path_buf());
+    }
+
+    bail!(
+        "Firmware directory not found. Checked:\n\
+         - /lib/firmware/ath11k/QCA206X/hw2.1/ (SteamOS)\n\
+         - /lib/firmware/ath11k/QCA2066/hw2.1/ (upstream)\n\
+         - /lib/firmware/ath11k/WCN6855/hw2.1/ (generic)"
+    );
+}
+
+/// Extract version string from a zstd-compressed firmware file
+fn extract_version_from_zst(zst_path: &Path) -> Result<String> {
+    // Use zstd crate to decompress
+    let file = File::open(zst_path)
+        .with_context(|| format!("Failed to open {}", zst_path.display()))?;
+
+    let decoder = zstd::stream::Decoder::new(file)
+        .with_context(|| format!("Failed to create zstd decoder for {}", zst_path.display()))?;
+
+    extract_version_from_reader(decoder)
+}
+
+/// Extract version string from an uncompressed firmware file
+fn extract_version_from_raw(path: &Path) -> Result<String> {
+    let file = File::open(path)
+        .with_context(|| format!("Failed to open {}", path.display()))?;
+
+    extract_version_from_reader(BufReader::new(file))
+}
+
+/// Extract QC_IMAGE_VERSION_STRING from a reader
+///
+/// Searches through the binary for the version string pattern
+fn extract_version_from_reader<R: Read>(mut reader: R) -> Result<String> {
+    // Read the file in chunks to find the version string
+    // The version string is embedded in the binary as: QC_IMAGE_VERSION_STRING=<version>
+    let pattern = b"QC_IMAGE_VERSION_STRING=";
+
+    // Read the entire file (firmware is ~5MB, manageable)
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data)
+        .context("Failed to read firmware data")?;
+
+    // Search for the pattern
+    if let Some(pos) = find_subsequence(&data, pattern) {
+        let start = pos + pattern.len();
+
+        // Find the end of the version string (null terminator or non-printable)
+        let mut end = start;
+        while end < data.len() && data[end] >= 0x20 && data[end] < 0x7F {
+            end += 1;
+        }
+
+        if end > start {
+            let version = String::from_utf8_lossy(&data[start..end]).to_string();
+            return Ok(version);
+        }
+    }
+
+    bail!("Could not find QC_IMAGE_VERSION_STRING in firmware binary")
+}
+
+/// Find a subsequence in a byte slice
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Fetch the latest upstream version from linux-firmware.git
+///
+/// Downloads the amss.bin file header to extract the version string
+pub fn get_upstream_version() -> Result<FirmwareVersion> {
+    // We could parse the WHENCE file, but it doesn't contain version strings.
+    // Instead, we'll fetch just enough of amss.bin to extract the version.
+    // The version string is typically within the first 1MB of the file.
+
+    let url = "https://gitlab.com/kernel-firmware/linux-firmware/-/raw/main/ath11k/QCA2066/hw2.1/amss.bin";
+
+    // Use reqwest to fetch a partial file (first 1MB should contain version)
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("Failed to create HTTP client")?;
+
+    // Request with Range header for partial download
+    let response = client
+        .get(url)
+        .header("Range", "bytes=0-1048575")  // First 1MB
+        .send()
+        .context("Failed to fetch upstream firmware")?;
+
+    if !response.status().is_success() && response.status().as_u16() != 206 {
+        bail!("Failed to fetch upstream firmware: HTTP {}", response.status());
+    }
+
+    let data = response.bytes().context("Failed to read response body")?;
+
+    // Search for version string
+    let pattern = b"QC_IMAGE_VERSION_STRING=";
+    if let Some(pos) = find_subsequence(&data, pattern) {
+        let start = pos + pattern.len();
+        let mut end = start;
+        while end < data.len() && data[end] >= 0x20 && data[end] < 0x7F {
+            end += 1;
+        }
+
+        if end > start {
+            let version = String::from_utf8_lossy(&data[start..end]).to_string();
+            return Ok(FirmwareVersion {
+                version_string: version,
+            });
+        }
+    }
+
+    bail!("Could not extract version from upstream firmware")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valve_stock_detection() {
+        let valve = FirmwareVersion {
+            version_string: "CI_WLAN.HSP.1.1-03926.9.1-QCAHSPSWPL_V2_SILICONZ_CE-15".to_string(),
+        };
+        assert!(valve.is_valve_stock());
+        assert!(!valve.is_upstream());
+
+        let upstream = FirmwareVersion {
+            version_string: "WLAN.HSP.1.1-03926.13-QCAHSPSWPL_V2_SILICONZ_CE-2.52297.9".to_string(),
+        };
+        assert!(!upstream.is_valve_stock());
+        assert!(upstream.is_upstream());
+    }
+}

--- a/src/firmware/version.rs
+++ b/src/firmware/version.rs
@@ -148,17 +148,17 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// Downloads the amss.bin file header to extract the version string
 pub fn get_upstream_version() -> Result<FirmwareVersion> {
     // We could parse the WHENCE file, but it doesn't contain version strings.
-    // Instead, we'll fetch just enough of amss.bin to extract the version.
-    // The version string is typically within the first 1MB of the file.
+    // Instead, we'll fetch enough of amss.bin to extract the version.
+    // The version string is located around 2-3MB into the file.
 
     let url = "https://gitlab.com/kernel-firmware/linux-firmware/-/raw/main/ath11k/QCA2066/hw2.1/amss.bin";
 
-    // Use system curl to fetch partial file (first 1MB should contain version)
+    // Use system curl to fetch partial file (first 4MB to ensure we get version string)
     let output = Command::new("curl")
         .args([
             "-sfL",                         // silent, fail on error, follow redirects
-            "--range", "0-1048575",         // First 1MB
-            "--max-time", "30",             // 30 second timeout
+            "--range", "0-4194303",         // First 4MB
+            "--max-time", "60",             // 60 second timeout for larger download
             url,
         ])
         .output()

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod network;
 mod system;
 mod config;
 mod utils;
+mod firmware;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -47,6 +48,11 @@ enum Commands {
     On,
     /// Bootstrap: Check and repair system service (runs on boot via user timer)
     Bootstrap,
+    /// Manage WiFi firmware updates (Steam Deck OLED only)
+    Firmware {
+        #[command(subcommand)]
+        action: firmware::FirmwareAction,
+    },
 }
 
 #[tokio::main]
@@ -55,13 +61,18 @@ async fn main() -> Result<()> {
     
     let cli = Cli::parse();
 
-    // Suppress INFO logs for status command (clean output)
-    if matches!(cli.command, Some(Commands::Status)) {
+    // Suppress INFO logs for status command and firmware status (clean output)
+    if matches!(cli.command, Some(Commands::Status))
+        || matches!(cli.command, Some(Commands::Firmware { action: firmware::FirmwareAction::Status { .. } }))
+    {
         log::set_max_level(log::LevelFilter::Warn);
     }
 
-    // Root check (except for status command)
-    if !matches!(cli.command, Some(Commands::Status)) && !utils::privilege::is_root() {
+    // Root check (except for status commands)
+    let needs_root = !matches!(cli.command, Some(Commands::Status))
+        && !matches!(cli.command, Some(Commands::Firmware { action: firmware::FirmwareAction::Status { .. } }));
+
+    if needs_root && !utils::privilege::is_root() {
         error!("This application must be run as root.");
         error!("Try: sudo hifi-wifi");
         std::process::exit(1);
@@ -101,6 +112,9 @@ async fn main() -> Result<()> {
         }
         Commands::Bootstrap => {
             run_bootstrap()?;
+        }
+        Commands::Firmware { action } => {
+            firmware::run_firmware(action, cli.dry_run)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,25 @@ async fn run_status_async() -> Result<()> {
     println!("{}│{}  Device: {:?}", BLUE, NC, power_mgr.device_type());
     let bat_pct = power_mgr.battery_percentage().map(|p| format!("{}%", p)).unwrap_or("N/A".to_string());
     println!("{}│{}  Power:  {:?} (Battery: {})", BLUE, NC, power_mgr.power_source(), bat_pct);
+
+    // Firmware info
+    if let Ok(fw_path) = crate::firmware::version::detect_firmware_path() {
+        if let Ok(fw_ver) = crate::firmware::version::FirmwareVersion::from_installed(&fw_path) {
+            let fw_type = if fw_ver.is_valve_stock() {
+                format!("{}(Valve stock){}", DIM, NC)
+            } else {
+                format!("{}(upstream){}", DIM, NC)
+            };
+            // Truncate version string for display
+            let ver_short = if fw_ver.version_string.len() > 40 {
+                format!("{}...", &fw_ver.version_string[..37])
+            } else {
+                fw_ver.version_string.clone()
+            };
+            println!("{}│{}  Network Card Firmware: {} {}", BLUE, NC, ver_short, fw_type);
+        }
+    }
+
     println!("{}└{}", BLUE, NC);
     println!();
 


### PR DESCRIPTION
This PR adds a `hifi-wifi firmware` command to manage QCA2066 WiFi firmware on Steam Deck OLED.

## Why?

Steam Deck OLED ships with Valve's fork of the ath11k firmware (version `WLAN.HMT.1.0.c5-00481-QCAHMTSWPL_V1.0_V2.0_SILICONZ-3`). The upstream linux-firmware repository has newer versions with bug fixes and improvements - currently at `WLAN.HMT.1.0.c5-00481-QCAHMTSWPL_V1.0_V2.0_SILICONZ-3.1`. 

Currently we can update our wifi module firmware from Oct 2023 to Aug 2025 version (or newer if they release them in future)

Theoretically we should get fewer disconnects with this latest firmware, lets see and test together
From my experience everything is smooth for now

## Where does the firmware come from?

Directly from the official linux-firmware repository maintained by the kernel community:

**Repository:** https://gitlab.com/kernel-firmware/linux-firmware
**Path:** `ath11k/QCA2066/hw2.1/`

This is the same firmware that ships with every major Linux distribution for this WiFi chip. We download three files:
- `amss.bin`
- `m3.bin`
- `board-2.bin`
## How to use?

- `hifi-wifi firmware status` - shows current vs latest available version
- `hifi-wifi firmware update` - downloads from linux-firmware and installs
- `hifi-wifi firmware restore` - restores from automatic backup

The command automatically backs up existing firmware before any changes, and can only be activated on actual Steam Deck OLED hardware

This is experimental. While the backup/restore should keep things safe, WiFi firmware updates carry some risk. 
The upstream firmware isn't specifically validated by Valve for Steam Deck - it's the generic Qualcomm firmware for this chip.